### PR TITLE
Add the possibility for the title and body to be templates.

### DIFF
--- a/example.js
+++ b/example.js
@@ -63,6 +63,15 @@ $(document).ready(function() {
     modal.render();
   });
 
+  $("#btn-5").click(function(e) {
+    var modal = new Backbone.ModalView({
+      model: new Backbone.Model({title: "Hello", name: "Example"}),
+      title: "<h3><%=title%></h3>",
+      body: "Hello, <%=name%>!",
+    });
+    modal.render();
+  });
+
   // Backbone.ShiftableCollection Example
   var ImageGallery = Backbone.ShiftableCollectionView.extend({
     template: _.template([

--- a/index.html
+++ b/index.html
@@ -5,17 +5,17 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-    
+
     <script src="3rd/jquery.min.js" type="text/javascript"></script>
     <script src="3rd/bootstrap.min.js" type="text/javascript"></script>
     <link href="3rd/bootstrap.min.css" rel="stylesheet" type="text/css" charset="utf-8">
 
     <script src="3rd/bootstrap-datepicker.js" type="text/javascript"></script>
     <link href="3rd/bootstrap-datepicker.css" rel="stylesheet" type="text/css" charset="utf-8">
-    
+
     <script src="3rd/underscore.js" type="text/javascript"></script>
     <script src="3rd/backbone.js" type="text/javascript"></script>
-    
+
     <script src="src/backbone-form.js" type="text/javascript"></script>
     <script src="src/backbone-modal.js" type="text/javascript"></script>
 
@@ -23,7 +23,7 @@
     <link href="src/backbone-shiftable-collection.css" rel="stylesheet" type="text/css" charset="utf-8">
 
     <script src="example.js" type="text/javascript"></script>
-    
+
     <style>
       header.navbar-inverse {border-radius: 0;}
       footer.navbar-default {border-radius: 0; margin-bottom: 0;}
@@ -84,8 +84,9 @@ events: {
           </p>
           <p>Backbone ModalView supports these options:</p>
           <ul>
-            <li><strong>title</strong>: Optional. HTML to put in the modal header. Defaults to &lt;h3&gt;Info&lt;/h3&gt;.</li>
-            <li><strong>body</strong>: Optional. HTML to put im the modal body. Defaults to an empty string.</li>
+            <li><strong>title</strong>: Optional. Underscore template or plain HTML string to put in the modal header. Defaults to &lt;h3&gt;Info&lt;/h3&gt;.</li>
+            <li><strong>body</strong>: Optional. Underscore template or plain HTML string to put in the modal body. Defaults to an empty string.</li>
+            <li><strong>model</strong>: Optional. Backbone.Model to be passed to the title and body templates. By default it is undefined.</li>
             <li>
               <strong>buttons</strong>: Optional. List of buttons to show. Defaults to a Close button. A button is an anchor tag with Bootstrap class btn. Each button has these options:
               <ul>
@@ -109,6 +110,8 @@ events: {
           <button id="btn-3" class="btn btn-primary">Subclassed modal dialog</button>
           &nbsp;
           <button id="btn-4" class="btn btn-primary">Static backdrop</button>
+          &nbsp;
+          <button id="btn-5" class="btn btn-primary">Body and Title as templates</button>
         </div>
       </div>
       <div class="row">
@@ -176,6 +179,15 @@ $("#btn-4").click(function(e) {
     title: "Static backdrop",
     body: "Hello World!",
     backdrop: 'static'
+  });
+  modal.render();
+});
+
+$("#btn-5").click(function(e) {
+  var modal = new Backbone.ModalView({
+    model: new Backbone.Model({title: "Hello", name: "Example"}),
+    title: "&lt;h3&gt;&lt;%=title%&gt;&lt;/h3&gt;",
+    body: "Hello, &lt;%=name%&gt;!",
   });
   modal.render();
 });

--- a/src/backbone-modal.js
+++ b/src/backbone-modal.js
@@ -50,13 +50,14 @@
       _.extend(this, _.pick(options, _.keys(this.defaults)));
       _.bindAll(this, "close");
     },
-    render: function(params) {
-      params || (params = {});
+    render: function() {
+      var data = this.model ? this.model.toJSON() : {};
+
       var view = this;
 
       this.$el.html(this.template({
-        title: _.template(this.title)(params),
-        body: _.template(this.body)(params)
+        title: _.template(this.title)(data),
+        body: _.template(this.body)(data)
       }));
 
       this.$header = this.$el.find('.modal-header');
@@ -86,7 +87,7 @@
       return this;
     },
     close: function(e) {
-      if (e.preventDefault) e.preventDefault();
+      if (e) e.preventDefault();
       var view = this;
       this.trigger("close", this);
       setTimeout(function() {

--- a/src/backbone-modal.js
+++ b/src/backbone-modal.js
@@ -50,13 +50,15 @@
       _.extend(this, _.pick(options, _.keys(this.defaults)));
       _.bindAll(this, "close");
     },
-    render: function() {
+    render: function(params) {
+      params || (params = {});
       var view = this;
 
       this.$el.html(this.template({
-        title: this.title,
-        body: this.body
+        title: _.template(this.title)(params),
+        body: _.template(this.body)(params)
       }));
+
       this.$header = this.$el.find('.modal-header');
       this.$body = this.$el.find('.modal-body');
       this.$footer = this.$el.find('.modal-footer');
@@ -78,13 +80,13 @@
       if(this.backdrop === true) {
         $('.modal-backdrop').off().click(view.close);
       }
-      
+
       this.postRender();
 
       return this;
     },
     close: function(e) {
-      if (e) e.preventDefault();
+      if (e.preventDefault) e.preventDefault();
       var view = this;
       this.trigger("close", this);
       setTimeout(function() {


### PR DESCRIPTION
I used the backbone modal widget for a course project and found that I needed the body of the modal to be a template. I think this should work well even if the body is plain html.