### PR TITLE
[backbone-bootstrap-widgets] - Fix bower.json, when you try to run bower info backbone-bootstrap-widgets #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ http://amiliaapp.github.io/backbone-bootstrap-widgets/
 With npm
 
 ```bash
-    npm install backbone-bootstrap-widgets --save
+npm install backbone-bootstrap-widgets --save
 ```
 
 With bower
 
 ```bash
-    bower install backbone-bootstrap-widgets --save
+bower install backbone-bootstrap-widgets --save
 ```
 
 * * *

--- a/bower.json
+++ b/bower.json
@@ -27,9 +27,11 @@
   ],
   "main": [
     "src/backbone-modal.js",
-    "src/backbone-shiftable-collection.js", "src/backbone-shiftable-collection.css", "src/backbone-shiftable-collection.less",
+    "src/backbone-shiftable-collection.js",
+    "src/backbone-shiftable-collection.css",
+    "src/backbone-shiftable-collection.less",
     "src/backbone-form.js"
   ],
   "license": "MIT",
-  "readme": "Series of widgets implemented as Backbone Views wrapping Bootstrap plugins.\n- ModalView creates a Backbone View wrapping a Bootstrap modal dialog. You can fill in the moal body in the render function.\n- ShiftableCollectionView creates a Backbone View wrapping a Backbone Collection. Allows you to shift models left and right to reorder, and to remove models.\n- FormView creates a Backbone View using Bootstrap form markup and styling. Implements bindings to update the Backbone Model based on DOM changes made by the user. (Deprecated Replaced by Backform)"
+  "readme": "Series of widgets implemented as Backbone Views wrapping Bootstrap plugins. ModalView creates a Backbone View wrapping a Bootstrap modal dialog. You can fill in the modal body in the render function. ShiftableCollectionView creates a Backbone View wrapping a Backbone Collection. Allows you to shift models left and right to reorder, and to remove models. FormView creates a Backbone View using Bootstrap form markup and styling. Implements bindings to update the Backbone Model based on DOM changes made by the user. (Deprecated Replaced by Backform)"
 }


### PR DESCRIPTION
The error was in the `readme` section into  bower.json file, due to the `\n`