### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
 		"src/backbone-shiftable-collection.js", "src/backbone-shiftable-collection.css", "src/backbone-shiftable-collection.less",
 		"src/backbone-form.js"
 	],
-	"license": {
-		"type": "MIT",
-		"url": "https://github.com/AmiliaApp/backbone-bootstrap-widgets/blob/gh-pages/LICENSE"
-	},
+	"license": "MIT",
 	"readme": "Series of widgets implemented as Backbone Views wrapping Bootstrap plugins.\n- ModalView creates a Backbone View wrapping a Bootstrap modal dialog. You can fill in the moal body in the render function.\n- ShiftableCollectionView creates a Backbone View wrapping a Backbone Collection. Allows you to shift models left and right to reorder, and to remove models.\n- FormView creates a Backbone View using Bootstrap form markup and styling. Implements bindings to update the Backbone Model based on DOM changes made by the user. (Deprecated Replaced by Backform)"
 }


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)